### PR TITLE
Added forvo local source to default config

### DIFF
--- a/config.json
+++ b/config.json
@@ -17,11 +17,16 @@
     },
     {
       "priority": 4,
+      "name": "ForvoLocal",
+      "url": "http://localhost:5050/?sources=forvo&term={word}&reading={reading}"
+    },
+    {
+      "priority": 5,
       "name": "JPod101",
       "url": "https://assets.languagepod101.com/dictionary/japanese/audiomp3.php?kanji={word}&kana={reading}"
     },
     {
-      "priority": 5,
+      "priority": 6,
       "name": "Forvo",
       "url": "http://localhost:8770/?expression={word}&reading={reading}"
     }


### PR DESCRIPTION
Renji-xd recently-ish was able to scrape forvo audio from select users, and now Forvo is supported as a source for the local audio server (link [here](https://github.com/Aquafina-water-bottle/local-audio-yomichan)). This PR simply adds that source.