### PR TITLE
Fix anki crash when deleting audio sources

### DIFF
--- a/main.py
+++ b/main.py
@@ -120,7 +120,6 @@ class BulkGenerateDialog(QDialog):
         self.nids = nids
         self.num_sources = 0
         self.sources = []
-        self.sources_vbox = QVBoxLayout()
 
         self._setupUi()
 
@@ -184,6 +183,9 @@ class BulkGenerateDialog(QDialog):
         """
         Sets up all the UI elements in the main BulkGenerateDialog window
         """
+        self.sources_vbox = QVBoxLayout()
+        self.sources_vbox.addStretch(1)
+
         # Target audio field, Filter kana field, Delay spin box, and Duplicate check box
         flabel = QLabel("Audio field:")
         flabel.setToolTip("This specifies the field that will get REPLACED with the downloaded audio clip on every selected card")
@@ -313,13 +315,15 @@ class BulkGenerateDialog(QDialog):
         """
         Removes a source from the list of sources
         """
-        self.num_sources -= 1
         deleteItemsOfLayout(self.sources[source - 1])
         self.sources_vbox.removeItem(self.sources[source - 1])
-        for source_id in range(source + 1, self.num_sources + 2):
-            self.sources[source_id - 1].changePriorityNumber(-1)
-            self.sources_vbox.removeItem(self.sources[source_id - 1])
-            self.sources_vbox.insertLayout(source_id-1, self.sources[source_id - 1])
+
+        for source_id in range(source - 1, self.num_sources):
+            self.sources[source_id].changePriorityNumber(-1)
+            self.sources_vbox.removeItem(self.sources[source_id])
+            self.sources_vbox.insertLayout(source_id, self.sources[source_id])
+
+        self.num_sources -= 1
 
         del self.sources[source - 1]
 
@@ -338,11 +342,12 @@ class BulkGenerateDialog(QDialog):
         """
         Adds a new SourceHBox to the list of sources
         """
-        self.num_sources += 1
         source = SourceHBox(priority=self.num_sources, changePriority=self._changePriority, removeSource=self._removeSource,
                              parentDialog=self)
         self.sources.append(source)
-        self.sources_vbox.addLayout(source)
+        self.sources_vbox.insertLayout(self.num_sources, source)
+
+        self.num_sources += 1
 
     def onGenerate(self):
         """


### PR DESCRIPTION
Hey, 

Thanks for this addon, I just migrated thousands of cards with this. But it was constantly crashing when I was playing around with the audio sources, and I decided to waste an hour not studying japanese and diagnosed the crash. Basically the logic for removing sources specifically was off, and also to fix the formatting of the layout I added qt stretch to the layout. It still doesn't really work once you get past 10 or so sources, but it didn't before either and I highly doubt people are using it like that. I specifically wanted only 1 source, and was unable to delete everything except one line before

B0sh