### PR TITLE
Add fallback file extension

### DIFF
--- a/audiodownloader.py
+++ b/audiodownloader.py
@@ -91,6 +91,8 @@ def get_request(url, allow_redirects=True):
                 audio_ext = '.mp3'
             elif 'aac' in content_type:
                 audio_ext = '.aac'
+            else:
+                audio_ext = os.path.splitext(url)[1]
     payload = response.content
     response.close()
 


### PR DESCRIPTION
If mimetypes.guess_extension() cannot guess the file extension, and neither of the two hardcoded cases for mp3 or aac are met, the file silently fails to download. In this case, defer to the URL itself.